### PR TITLE
feat: implement Pages CMS entity

### DIFF
--- a/admin/CACHE.md
+++ b/admin/CACHE.md
@@ -21,6 +21,7 @@ Legend: `[ ]` not started, `[x]` implemented.
 | 5 | `products.slug.{slug}` | Single product record (with images, attributes, brand, category) | 30 min | Product saved / deleted |
 | 6 | `products.category.{category_id}` | Published products list for a category page | 15 min | Product saved / deleted |
 | 7 | `varieties.product.{product_id}` | All varieties for a product (price, inventory, status) | 15 min | Variety saved / deleted |
+| 9 | `pages.{slug}` | Single published page record | 1 hour | Page saved / deleted |
 
 ---
 

--- a/admin/IMPLEMENTATION.md
+++ b/admin/IMPLEMENTATION.md
@@ -27,6 +27,7 @@ Catalog layer and platform basics.
 - [x] Banners (polymorphic images via `images` table)
 - [x] Sliders + Slides (each slide has one polymorphic image via `images` table)
 - [x] Menus + Menu Items (nested via `parent_id`; optional polymorphic image per item)
+- [x] Pages (CMS static pages; polymorphic image; SCHEDULED status with `published_at`)
 - [~] Addresses (model only, no resource yet)
 
 Sample data for manual admin testing lives in `TestSeeder` (`php artisan db:seed --class=TestSeeder`); `DatabaseSeeder` holds only necessary data.
@@ -62,7 +63,7 @@ Depend mostly on Images only.
 - [x] Banners
 - [x] Sliders + Slides
 - [x] Menus + Menu Items
-- [ ] Pages
+- [x] Pages
 - [ ] FAQs
 - [ ] Reviews
 - [ ] Wishlists

--- a/admin/app/Enums/PageStatusEnum.php
+++ b/admin/app/Enums/PageStatusEnum.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Traits\HasOptions;
+
+enum PageStatusEnum: int
+{
+    use HasOptions;
+
+    case DELETED = 10;
+    case PUBLISHED = 20;
+    case DRAFT = 30;
+    case SCHEDULED = 40;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DELETED => 'Deleted',
+            self::PUBLISHED => 'Published',
+            self::DRAFT => 'Draft',
+            self::SCHEDULED => 'Scheduled',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::DELETED => 'danger',
+            self::PUBLISHED => 'success',
+            self::DRAFT => 'warning',
+            self::SCHEDULED => 'info',
+        };
+    }
+}

--- a/admin/app/Filament/Resources/PageResource.php
+++ b/admin/app/Filament/Resources/PageResource.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use AmidEsfahani\FilamentTinyEditor\TinyEditor;
+use App\Enums\PageStatusEnum;
+use App\Filament\Resources\PageResource\Pages\CreatePage;
+use App\Filament\Resources\PageResource\Pages\EditPage;
+use App\Filament\Resources\PageResource\Pages\ListPages;
+use App\Models\Page as PageModel;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class PageResource extends Resource
+{
+    protected static ?string $model = PageModel::class;
+
+    protected static string | \UnitEnum | null $navigationGroup = 'Content';
+
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?int $navigationSort = 6;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('heading')
+                    ->required()
+                    ->maxLength(255)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (string $operation, ?string $state, Set $set): void {
+                        if ($operation === 'create') {
+                            $set('slug', Str::slug((string) $state));
+                        }
+                    })
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('The page title shown to visitors, e.g. "About Us".'),
+                TextInput::make('slug')
+                    ->disabled()
+                    ->dehydrated()
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(PageModel::class, 'slug', ignoreRecord: true)
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('Auto-generated from the heading. Used as the URL path, e.g. /about-us.'),
+                TinyEditor::make('content')
+                    ->nullable()
+                    ->columnSpanFull()
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('The main body content of the page, edited with the rich text editor.'),
+                TextInput::make('title')
+                    ->maxLength(255)
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('SEO page title shown in the browser tab and search results. Leave blank to use the heading.'),
+                TextInput::make('description')
+                    ->maxLength(255)
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('Meta description shown in search engine results. Aim for 150-160 characters.'),
+                Toggle::make('no_index')
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('When enabled, search engines are instructed not to index this page.'),
+                TextInput::make('canonical')
+                    ->maxLength(255)
+                    ->url()
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('Canonical URL to prevent duplicate content issues. Leave blank unless this page should point to another URL.'),
+                Select::make('status')
+                    ->required()
+                    ->live()
+                    ->options(PageStatusEnum::options())
+                    ->default(PageStatusEnum::PUBLISHED->value)
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('Published: visible on the frontend. Draft: hidden. Scheduled: published on the date set below. Deleted: removed from listings.'),
+                DateTimePicker::make('published_at')
+                    ->nullable()
+                    ->required(fn (Get $get): bool => (int) $get('status') === PageStatusEnum::SCHEDULED->value)
+                    ->hidden(fn (Get $get): bool => (int) $get('status') !== PageStatusEnum::SCHEDULED->value)
+                    ->hintIcon('heroicon-o-information-circle')
+                    ->hintIconTooltip('The date and time this page will be made public. Only applies when status is Scheduled.'),
+                Fieldset::make('Image')
+                    ->relationship('image')
+                    ->schema([
+                        FileUpload::make('path')
+                            ->image()
+                            ->nullable()
+                            ->columnSpanFull(),
+                        TextInput::make('alt_text')
+                            ->nullable()
+                            ->maxLength(255),
+                    ])
+                    ->mutateRelationshipDataBeforeSaveUsing(function (array $data, PageModel $record): array {
+                        if (empty($data['path'])) {
+                            $record->image?->delete();
+                        }
+
+                        return $data;
+                    })
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('heading')
+                    ->limit(30)
+                    ->wrap()
+                    ->searchable(),
+                TextColumn::make('slug')
+                    ->limit(30)
+                    ->wrap()
+                    ->searchable(),
+                IconColumn::make('no_index')
+                    ->boolean(),
+                TextColumn::make('status')
+                    ->getStateUsing(fn (PageModel $record): string => $record->status->label())
+                    ->color(fn (PageModel $record): string => $record->status->color())
+                    ->sortable(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPages::route('/'),
+            'create' => CreatePage::route('/create'),
+            'edit' => EditPage::route('/{record}/edit'),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/PageResource/Pages/CreatePage.php
+++ b/admin/app/Filament/Resources/PageResource/Pages/CreatePage.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PageResource\Pages;
+
+use App\Filament\Resources\PageResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePage extends CreateRecord
+{
+    protected static string $resource = PageResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/admin/app/Filament/Resources/PageResource/Pages/EditPage.php
+++ b/admin/app/Filament/Resources/PageResource/Pages/EditPage.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PageResource\Pages;
+
+use App\Filament\Resources\PageResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPage extends EditRecord
+{
+    protected static string $resource = PageResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/admin/app/Filament/Resources/PageResource/Pages/ListPages.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PageResource\Pages;
+
+use App\Filament\Resources\PageResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPages extends ListRecords
+{
+    protected static string $resource = PageResource::class;
+
+    protected ?string $subheading = 'Manage static content pages such as About Us, Contact, and FAQ.';
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/admin/app/Models/Page.php
+++ b/admin/app/Models/Page.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\PageStatusEnum;
+use Carbon\Carbon;
+use Database\Factories\PageFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+/**
+ * @property positive-int $id
+ * @property string $heading
+ * @property string $slug
+ * @property string|null $content
+ * @property string|null $title
+ * @property string|null $description
+ * @property bool $no_index
+ * @property string|null $canonical
+ * @property PageStatusEnum $status
+ * @property Carbon|null $published_at
+ * @property Image|null $image
+ */
+class Page extends Model
+{
+    /** @use HasFactory<PageFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'heading',
+        'slug',
+        'content',
+        'title',
+        'description',
+        'no_index',
+        'canonical',
+        'status',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'no_index' => 'boolean',
+        'status' => PageStatusEnum::class,
+        'published_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (Page $page): void {
+            $page->image?->delete();
+        });
+    }
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
+}

--- a/admin/database/factories/PageFactory.php
+++ b/admin/database/factories/PageFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\PageStatusEnum;
+use App\Models\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Page>
+ */
+class PageFactory extends Factory
+{
+    protected $model = Page::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'heading' => fake()->words(4, true),
+            'slug' => fn (array $attributes): string => Str::slug($attributes['heading']) . '-' . fake()->unique()->numberBetween(1, 9999),
+            'content' => fake()->paragraphs(3, true),
+            'title' => fake()->words(5, true),
+            'description' => fake()->sentence(),
+            'no_index' => fake()->boolean(20),
+            'canonical' => null,
+            'status' => fake()->randomElement(PageStatusEnum::cases()),
+            'published_at' => null,
+        ];
+    }
+
+    public function withImage(): static
+    {
+        return $this->afterCreating(function (Page $page): void {
+            $page->image()->create([
+                'path' => fake()->imageUrl(),
+                'alt_text' => fake()->words(2, true),
+            ]);
+        });
+    }
+}

--- a/admin/database/migrations/2026_06_20_000005_create_pages_table.php
+++ b/admin/database/migrations/2026_06_20_000005_create_pages_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PageStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->string('heading');
+            $table->string('slug')->unique();
+            $table->longText('content')->nullable();
+            $table->string('title')->nullable();
+            $table->string('description')->nullable();
+            $table->boolean('no_index')->default(false);
+            $table->string('canonical')->nullable();
+            $table->unsignedTinyInteger('status')->default(PageStatusEnum::PUBLISHED->value);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};

--- a/admin/database/seeders/PageSeeder.php
+++ b/admin/database/seeders/PageSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Page;
+use Illuminate\Database\Seeder;
+
+class PageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Page::all()->each->delete();
+
+        Page::factory()->count(10)->withImage()->create();
+    }
+}

--- a/admin/database/seeders/TestSeeder.php
+++ b/admin/database/seeders/TestSeeder.php
@@ -20,6 +20,7 @@ class TestSeeder extends Seeder
             BannerSeeder::class,
             SliderSeeder::class,
             MenuSeeder::class,
+            PageSeeder::class,
         ]);
     }
 }

--- a/admin/tests/Feature/Filament/Resource/PageResourceTest.php
+++ b/admin/tests/Feature/Filament/Resource/PageResourceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\PageResource;
+use App\Models\Page;
+use Filament\Actions\DeleteAction;
+
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    login();
+});
+
+it('can render index page of the page resource.', function () {
+    get(PageResource::getUrl())->assertOk();
+});
+
+it('can list pages in the table.', function () {
+    $pages = Page::factory()->count(5)->create();
+
+    livewire(PageResource\Pages\ListPages::class)
+        ->assertCanSeeTableRecords($pages);
+});
+
+it('can render edit page.', function () {
+    $page = Page::factory()->create();
+
+    get(PageResource::getUrl('edit', [
+        'record' => $page,
+    ]))->assertOk();
+});
+
+it('can update page model.', function () {
+    $page = Page::factory()->create();
+    $newPage = Page::factory()->make();
+
+    livewire(PageResource\Pages\EditPage::class, [
+        'record' => $page->getRouteKey(),
+    ])
+        ->fillForm([
+            'heading' => $newPage->heading,
+            'slug' => $newPage->slug,
+            'title' => $newPage->title,
+            'description' => $newPage->description,
+            'no_index' => $newPage->no_index,
+            'status' => $newPage->status->value,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($page->refresh())
+        ->heading->toBe($newPage->heading)
+        ->slug->toBe($newPage->slug)
+        ->status->toBe($newPage->status);
+});
+
+it('can create page model.', function () {
+    $newPage = Page::factory()->make();
+
+    livewire(PageResource\Pages\CreatePage::class)
+        ->fillForm([
+            'heading' => $newPage->heading,
+            'slug' => $newPage->slug,
+            'title' => $newPage->title,
+            'description' => $newPage->description,
+            'no_index' => $newPage->no_index,
+            'status' => $newPage->status->value,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(Page::class, [
+        'heading' => $newPage->heading,
+        'slug' => $newPage->slug,
+        'status' => $newPage->status->value,
+    ]);
+});
+
+it('can delete page model.', function () {
+    $page = Page::factory()->create();
+
+    livewire(PageResource\Pages\EditPage::class, [
+        'record' => $page->getRouteKey(),
+    ])
+        ->callAction(DeleteAction::class);
+
+    $this->assertModelMissing($page);
+});
+
+it('deletes image when page is deleted.', function () {
+    $page = Page::factory()->withImage()->create();
+    $image = $page->image;
+
+    livewire(PageResource\Pages\EditPage::class, [
+        'record' => $page->getRouteKey(),
+    ])
+        ->callAction(DeleteAction::class);
+
+    $this->assertModelMissing($page);
+    $this->assertModelMissing($image);
+});


### PR DESCRIPTION
- Add PageStatusEnum (DELETED/PUBLISHED/DRAFT/SCHEDULED)
- Add create_pages_table migration (heading, slug unique, content, SEO fields, status, published_at)
- Add Page model with MorphOne image and cascade-delete hook
- Add PageFactory with withImage state
- Add PageSeeder integrated into TestSeeder
- Add PageResource with auto-slug, TinyEditor, conditional published_at (required when Scheduled), image Fieldset, hints
- Add PageResourceTest covering CRUD and cascade image deletion
- Update CACHE.md with pages.{slug} key and IMPLEMENTATION.md