### PR TITLE
feat: implement Receipts with inline relation manager

### DIFF
--- a/admin/app/Enums/ReceiptTypeEnum.php
+++ b/admin/app/Enums/ReceiptTypeEnum.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Traits\HasOptions;
+
+enum ReceiptTypeEnum: int
+{
+    use HasOptions;
+
+    case RECEIPT = 1;
+    case PREPAYMENT = 2;
+    case SHIPPING_REQUEST = 3;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::RECEIPT => trans('receipt.type_receipt'),
+            self::PREPAYMENT => trans('receipt.type_prepayment'),
+            self::SHIPPING_REQUEST => trans('receipt.type_shipping_request'),
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::RECEIPT => 'success',
+            self::PREPAYMENT => 'info',
+            self::SHIPPING_REQUEST => 'warning',
+        };
+    }
+}

--- a/admin/app/Filament/Resources/OrderResource.php
+++ b/admin/app/Filament/Resources/OrderResource.php
@@ -12,6 +12,7 @@ use App\Filament\Resources\OrderResource\Pages\ListOrders;
 use App\Filament\Resources\OrderResource\RelationManagers\OrderNotesRelationManager;
 use App\Filament\Resources\OrderResource\RelationManagers\OrderShippingsRelationManager;
 use App\Filament\Resources\OrderResource\RelationManagers\OrderVarietiesRelationManager;
+use App\Filament\Resources\OrderResource\RelationManagers\ReceiptsRelationManager;
 use App\Models\Order;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -262,6 +263,7 @@ class OrderResource extends Resource
         return [
             OrderVarietiesRelationManager::class,
             OrderShippingsRelationManager::class,
+            ReceiptsRelationManager::class,
             OrderNotesRelationManager::class,
         ];
     }

--- a/admin/app/Filament/Resources/OrderResource/RelationManagers/ReceiptsRelationManager.php
+++ b/admin/app/Filament/Resources/OrderResource/RelationManagers/ReceiptsRelationManager.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\OrderResource\RelationManagers;
+
+use App\Enums\ReceiptTypeEnum;
+use App\Models\Receipt;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ReceiptsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'receipts';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('user_id')
+                    ->label(trans('receipt.user_id'))
+                    ->relationship('user', 'email')
+                    ->searchable()
+                    ->preload()
+                    ->native(false),
+                Select::make('type')
+                    ->label(trans('receipt.type'))
+                    ->required()
+                    ->options(ReceiptTypeEnum::options())
+                    ->default(ReceiptTypeEnum::RECEIPT->value),
+                TextInput::make('amount')
+                    ->label(trans('receipt.amount'))
+                    ->required()
+                    ->numeric()
+                    ->default(0),
+                TextInput::make('tracking_code')
+                    ->label(trans('receipt.tracking_code'))
+                    ->maxLength(255),
+                DateTimePicker::make('paid_at')
+                    ->label(trans('receipt.paid_at')),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('id')
+            ->columns([
+                TextColumn::make('type')
+                    ->label(trans('receipt.type'))
+                    ->badge()
+                    ->getStateUsing(fn (Receipt $record): string => $record->type->label())
+                    ->color(fn (Receipt $record): string => $record->type->color()),
+                TextColumn::make('amount')
+                    ->label(trans('receipt.amount'))
+                    ->numeric(),
+                TextColumn::make('paid_at')
+                    ->label(trans('receipt.paid_at'))
+                    ->dateTime(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                DeleteBulkAction::make(),
+            ]);
+    }
+}

--- a/admin/app/Filament/Resources/ReceiptResource.php
+++ b/admin/app/Filament/Resources/ReceiptResource.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\ReceiptTypeEnum;
+use App\Filament\Resources\ReceiptResource\Pages\CreateReceipt;
+use App\Filament\Resources\ReceiptResource\Pages\EditReceipt;
+use App\Filament\Resources\ReceiptResource\Pages\ListReceipts;
+use App\Models\Receipt;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ReceiptResource extends Resource
+{
+    protected static ?string $model = Receipt::class;
+
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-banknotes';
+
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('receipt.navigation_group');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans('receipt.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans('receipt.plural_label');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('user_id')
+                    ->label(trans('receipt.user_id'))
+                    ->relationship('user', 'email')
+                    ->searchable()
+                    ->preload()
+                    ->native(false),
+                Select::make('order_id')
+                    ->label(trans('receipt.order_id'))
+                    ->relationship('order', 'id')
+                    ->searchable()
+                    ->preload()
+                    ->native(false),
+                Select::make('type')
+                    ->label(trans('receipt.type'))
+                    ->required()
+                    ->options(ReceiptTypeEnum::options())
+                    ->default(ReceiptTypeEnum::RECEIPT->value),
+                TextInput::make('amount')
+                    ->label(trans('receipt.amount'))
+                    ->required()
+                    ->numeric()
+                    ->default(0),
+                TextInput::make('tracking_code')
+                    ->label(trans('receipt.tracking_code'))
+                    ->maxLength(255),
+                DateTimePicker::make('paid_at')
+                    ->label(trans('receipt.paid_at')),
+                TextInput::make('destination_name')
+                    ->label(trans('receipt.destination_name'))
+                    ->maxLength(255),
+                TextInput::make('destination_bank')
+                    ->label(trans('receipt.destination_bank'))
+                    ->maxLength(255),
+                TextInput::make('end_of_card_number')
+                    ->label(trans('receipt.end_of_card_number'))
+                    ->maxLength(4),
+                TextInput::make('card_id')
+                    ->label(trans('receipt.card_id'))
+                    ->numeric(),
+                Toggle::make('is_paya')
+                    ->label(trans('receipt.is_paya')),
+                Textarea::make('description')
+                    ->label(trans('receipt.description'))
+                    ->columnSpanFull(),
+                Fieldset::make(trans('receipt.image'))
+                    ->relationship('image')
+                    ->schema([
+                        FileUpload::make('path')
+                            ->label(trans('receipt.path'))
+                            ->image()
+                            ->nullable()
+                            ->columnSpanFull(),
+                        TextInput::make('alt_text')
+                            ->label(trans('receipt.alt_text'))
+                            ->nullable()
+                            ->maxLength(255),
+                    ])
+                    ->mutateRelationshipDataBeforeSaveUsing(function (array $data, Receipt $record): array {
+                        if (empty($data['path'])) {
+                            $record->image?->delete();
+                        }
+
+                        return $data;
+                    })
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('id')
+                    ->label('#')
+                    ->sortable(),
+                TextColumn::make('user.email')
+                    ->label(trans('receipt.user_id'))
+                    ->searchable(),
+                TextColumn::make('order_id')
+                    ->label(trans('receipt.order_id'))
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->label(trans('receipt.type'))
+                    ->badge()
+                    ->getStateUsing(fn (Receipt $record): string => $record->type->label())
+                    ->color(fn (Receipt $record): string => $record->type->color())
+                    ->sortable(),
+                TextColumn::make('amount')
+                    ->label(trans('receipt.amount'))
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('paid_at')
+                    ->label(trans('receipt.paid_at'))
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label(trans('receipt.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListReceipts::route('/'),
+            'create' => CreateReceipt::route('/create'),
+            'edit' => EditReceipt::route('/{record}/edit'),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/ReceiptResource/Pages/CreateReceipt.php
+++ b/admin/app/Filament/Resources/ReceiptResource/Pages/CreateReceipt.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ReceiptResource\Pages;
+
+use App\Filament\Resources\ReceiptResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateReceipt extends CreateRecord
+{
+    protected static string $resource = ReceiptResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/admin/app/Filament/Resources/ReceiptResource/Pages/EditReceipt.php
+++ b/admin/app/Filament/Resources/ReceiptResource/Pages/EditReceipt.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ReceiptResource\Pages;
+
+use App\Filament\Resources\ReceiptResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditReceipt extends EditRecord
+{
+    protected static string $resource = ReceiptResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/ReceiptResource/Pages/ListReceipts.php
+++ b/admin/app/Filament/Resources/ReceiptResource/Pages/ListReceipts.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\ReceiptResource\Pages;
+
+use App\Filament\Resources\ReceiptResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListReceipts extends ListRecords
+{
+    protected static string $resource = ReceiptResource::class;
+
+    protected ?string $subheading = null;
+
+    public function mount(): void
+    {
+        parent::mount();
+        $this->subheading = trans('receipt.subheading');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/admin/app/Models/Order.php
+++ b/admin/app/Models/Order.php
@@ -58,6 +58,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Collection<OrderVariety> $orderVarieties
  * @property Collection<OrderNote> $orderNotes
  * @property Collection<OrderShipping> $orderShippings
+ * @property Collection<Receipt> $receipts
  */
 class Order extends Model
 {
@@ -155,5 +156,10 @@ class Order extends Model
     public function orderShippings(): HasMany
     {
         return $this->hasMany(OrderShipping::class);
+    }
+
+    public function receipts(): HasMany
+    {
+        return $this->hasMany(Receipt::class);
     }
 }

--- a/admin/app/Models/Receipt.php
+++ b/admin/app/Models/Receipt.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ReceiptTypeEnum;
+use Carbon\Carbon;
+use Database\Factories\ReceiptFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+/**
+ * @property positive-int $id
+ * @property positive-int|null $user_id
+ * @property positive-int|null $card_id
+ * @property positive-int $amount
+ * @property positive-int|null $order_id
+ * @property string|null $tracking_code
+ * @property Carbon|null $paid_at
+ * @property string|null $destination_name
+ * @property string|null $destination_bank
+ * @property string|null $end_of_card_number
+ * @property string|null $description
+ * @property bool|null $is_paya
+ * @property ReceiptTypeEnum $type
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property User|null $user
+ * @property Order|null $order
+ * @property Image|null $image
+ */
+class Receipt extends Model
+{
+    /** @use HasFactory<ReceiptFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'card_id',
+        'amount',
+        'order_id',
+        'tracking_code',
+        'paid_at',
+        'destination_name',
+        'destination_bank',
+        'end_of_card_number',
+        'description',
+        'is_paya',
+        'type',
+    ];
+
+    protected $casts = [
+        'paid_at' => 'datetime',
+        'is_paya' => 'boolean',
+        'type' => ReceiptTypeEnum::class,
+    ];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (Receipt $receipt): void {
+            $receipt->image?->delete();
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function image(): MorphOne
+    {
+        return $this->morphOne(Image::class, 'imageable');
+    }
+}

--- a/admin/database/factories/ReceiptFactory.php
+++ b/admin/database/factories/ReceiptFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\ReceiptTypeEnum;
+use App\Models\Receipt;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Receipt>
+ */
+class ReceiptFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'card_id' => null,
+            'amount' => fake()->numberBetween(100_000, 10_000_000),
+            'order_id' => null,
+            'tracking_code' => fake()->optional()->numerify('##########'),
+            'paid_at' => fake()->optional()->dateTimeThisYear(),
+            'destination_name' => fake()->optional()->name(),
+            'destination_bank' => fake()->optional()->company(),
+            'end_of_card_number' => fake()->optional()->numerify('####'),
+            'description' => fake()->optional()->sentence(),
+            'is_paya' => fake()->boolean(),
+            'type' => fake()->randomElement(ReceiptTypeEnum::cases()),
+        ];
+    }
+
+    public function withImage(): static
+    {
+        return $this->afterCreating(function (Receipt $receipt): void {
+            $receipt->image()->create([
+                'path' => fake()->imageUrl(),
+                'alt_text' => fake()->words(2, true),
+            ]);
+        });
+    }
+}

--- a/admin/database/migrations/2026_06_20_000018_create_receipts_table.php
+++ b/admin/database/migrations/2026_06_20_000018_create_receipts_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ReceiptTypeEnum;
+use App\Models\Order;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('receipts', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(User::class)->nullable()->constrained()->nullOnDelete();
+
+            // cards / saved-cards table is not built yet (Phase 5), so this
+            // stays a plain nullable column with no FK constraint.
+            $table->unsignedBigInteger('card_id')->nullable();
+
+            $table->decimal('amount', 12, 2)->default(0);
+            $table->foreignIdFor(Order::class)->nullable()->constrained()->nullOnDelete();
+            $table->string('tracking_code')->nullable();
+            $table->dateTime('paid_at')->nullable();
+            $table->string('destination_name')->nullable();
+            $table->string('destination_bank')->nullable();
+            $table->string('end_of_card_number')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('is_paya')->nullable();
+            $table->unsignedTinyInteger('type')->default(ReceiptTypeEnum::RECEIPT->value);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('receipts');
+    }
+};

--- a/admin/database/seeders/ReceiptSeeder.php
+++ b/admin/database/seeders/ReceiptSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Receipt;
+use Illuminate\Database\Seeder;
+
+class ReceiptSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Receipt::all()->each->delete();
+
+        Receipt::factory()->count(20)->create();
+    }
+}

--- a/admin/database/seeders/TestSeeder.php
+++ b/admin/database/seeders/TestSeeder.php
@@ -29,6 +29,7 @@ class TestSeeder extends Seeder
             OrderVarietySeeder::class,
             OrderShippingSeeder::class,
             OrderNoteSeeder::class,
+            ReceiptSeeder::class,
             ShippingLineSeeder::class,
             ShippingMethodSeeder::class,
             ShippingCitySeeder::class,

--- a/admin/docs/IMPLEMENTATION.md
+++ b/admin/docs/IMPLEMENTATION.md
@@ -105,7 +105,7 @@ The main goal; depends on most of phases 1-3.
 - [x] `order_shippings` (fulfillment/shipment records: model, migration, factory, seeder, `OrderShippingPaymentTypeEnum`, Filament resource (+ pages), inline relation manager on Order, tests)
 - [x] `order_notes` (internal staff notes: model, migration, factory, seeder, Filament resource (+ pages), inline relation manager on Order, tests)
 - [~] `order_logs`, `order_call_logs` — NOT IMPLEMENTED (not needed for current scope)
-- [ ] Receipts
+- [x] Receipts (payment receipts: model, migration, factory, seeder, `ReceiptTypeEnum`, polymorphic image, Filament resource (+ pages), inline relation manager on Order, tests. `card_id` kept nullable without FK since cards are not built)
 - [ ] Transactions
 - [ ] Gateways
 

--- a/admin/docs/ORDER.md
+++ b/admin/docs/ORDER.md
@@ -46,3 +46,12 @@ Only consider this if real lost sales, oversell complaints, or flash sales appea
 - Same transaction + `SELECT ... FOR UPDATE` rule applies when reserving.
 
 Preferred shape if B is needed: a `reservations` table (`variety_id`, `quantity`, `user_id`/`session_id`, `order_id`, `expires_at`, `status`) rather than a bare `reserved` counter, because it is auditable and easier to expire correctly.
+
+## Payments: receipts vs transactions/gateways
+
+Two payment paths, kept separate:
+
+- Manual / offline payments use `receipts` (built): card-to-card, Paya transfers, prepayments. The customer provides a tracking code or uploads a receipt image, and staff confirm it. Fields: `destination_bank`, `end_of_card_number`, `tracking_code`, `is_paya`, plus a polymorphic receipt image.
+- Online gateway payments will use `transactions` + `gateways` (not built yet): Mellat, Parsian, Zarinpal. These record the gateway result automatically.
+
+Keep `receipts` if there is any chance of manual bank transfers (typical for Iranian shops). If the shop ever becomes gateway-only, `transactions`/`gateways` would cover everything and `receipts` could be retired.

--- a/admin/docs/ShoFlow db doc.md
+++ b/admin/docs/ShoFlow db doc.md
@@ -626,6 +626,15 @@ Used to store products.
 * The `is_paya` column indicates whether this transfer is a Paya transfer (nullable).  
 * The `type` column stores the type of receipt: 1-Receipt, 2-Prepayment, 3-Shipping Request (default 1).
 
+Implementation notes:
+
+* `type`: `ReceiptTypeEnum` (`RECEIPT=1` default, `PREPAYMENT=2`, `SHIPPING_REQUEST=3`).
+* `user_id`: nullable FK to `users` (`nullOnDelete`). `order_id`: nullable FK to `orders` (`nullOnDelete`) so receipts survive order deletion.
+* `card_id`: plain nullable column with no FK; the cards / saved-cards table is not built yet (Phase 5).
+* `image_id` from the doc is implemented as the project-standard polymorphic image (`morphOne` on `images`), not a column. Deleting a receipt deletes its image.
+* `amount` is `decimal(12,2)`; `is_paya` is a nullable boolean.
+* Editable inline on the Order edit page via `ReceiptsRelationManager`.
+
 # reviews
 
 * Contains user reviews for each product.

--- a/admin/lang/en/receipt.php
+++ b/admin/lang/en/receipt.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'Receipt',
+    'plural_label' => 'Receipts',
+    'navigation_group' => 'Commerce',
+    'subheading' => 'Payment receipts recorded against users and (optionally) orders, including bank transfer details.',
+
+    'user_id' => 'User',
+    'card_id' => 'Card ID',
+    'amount' => 'Amount',
+    'order_id' => 'Order',
+    'tracking_code' => 'Tracking Code',
+    'paid_at' => 'Paid At',
+    'destination_name' => 'Account Receiver',
+    'destination_bank' => 'Bank',
+    'end_of_card_number' => 'Card Last 4 Digits',
+    'description' => 'Description',
+    'is_paya' => 'Paya Transfer',
+    'type' => 'Type',
+    'image' => 'Receipt Image',
+    'path' => 'Image File',
+    'alt_text' => 'Alt Text',
+    'created_at' => 'Created At',
+    'updated_at' => 'Updated At',
+
+    'type_receipt' => 'Receipt',
+    'type_prepayment' => 'Prepayment',
+    'type_shipping_request' => 'Shipping Request',
+];

--- a/admin/lang/fa/receipt.php
+++ b/admin/lang/fa/receipt.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'رسید',
+    'plural_label' => 'رسیدها',
+    'navigation_group' => 'فروش',
+    'subheading' => 'رسیدهای پرداخت ثبت‌شده برای کاربران و (در صورت وجود) سفارش‌ها، همراه با اطلاعات انتقال بانکی.',
+
+    'user_id' => 'کاربر',
+    'card_id' => 'شناسه کارت',
+    'amount' => 'مبلغ',
+    'order_id' => 'سفارش',
+    'tracking_code' => 'کد پیگیری',
+    'paid_at' => 'تاریخ پرداخت',
+    'destination_name' => 'دریافت‌کننده حساب',
+    'destination_bank' => 'بانک',
+    'end_of_card_number' => 'چهار رقم آخر کارت',
+    'description' => 'توضیحات',
+    'is_paya' => 'انتقال پایا',
+    'type' => 'نوع',
+    'image' => 'تصویر رسید',
+    'path' => 'فایل تصویر',
+    'alt_text' => 'متن جایگزین',
+    'created_at' => 'تاریخ ایجاد',
+    'updated_at' => 'تاریخ بروزرسانی',
+
+    'type_receipt' => 'رسید',
+    'type_prepayment' => 'پیش‌پرداخت',
+    'type_shipping_request' => 'درخواست ارسال',
+];

--- a/admin/tests/Feature/Filament/Resource/ReceiptResourceTest.php
+++ b/admin/tests/Feature/Filament/Resource/ReceiptResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ReceiptTypeEnum;
+use App\Filament\Resources\ReceiptResource;
+use App\Models\Receipt;
+use App\Models\User;
+use Filament\Actions\DeleteAction;
+
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    login();
+});
+
+it('can render index page of the receipt resource.', function () {
+    get(ReceiptResource::getUrl())->assertOk();
+});
+
+it('can list receipts in the table.', function () {
+    $receipts = Receipt::factory()->count(5)->create();
+
+    livewire(ReceiptResource\Pages\ListReceipts::class)
+        ->assertCanSeeTableRecords($receipts);
+});
+
+it('can render edit receipt page.', function () {
+    $receipt = Receipt::factory()->create();
+
+    get(ReceiptResource::getUrl('edit', [
+        'record' => $receipt,
+    ]))->assertOk();
+});
+
+it('can create receipt model.', function () {
+    $user = User::factory()->create();
+
+    livewire(ReceiptResource\Pages\CreateReceipt::class)
+        ->fillForm([
+            'user_id' => $user->id,
+            'type' => ReceiptTypeEnum::PREPAYMENT->value,
+            'amount' => 1_500_000,
+            'tracking_code' => 'TRK123',
+            'is_paya' => true,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(Receipt::class, [
+        'user_id' => $user->id,
+        'type' => ReceiptTypeEnum::PREPAYMENT->value,
+        'amount' => 1_500_000,
+        'tracking_code' => 'TRK123',
+    ]);
+});
+
+it('can delete receipt model.', function () {
+    $receipt = Receipt::factory()->create();
+
+    livewire(ReceiptResource\Pages\EditReceipt::class, [
+        'record' => $receipt->getRouteKey(),
+    ])
+        ->callAction(DeleteAction::class);
+
+    $this->assertModelMissing($receipt);
+});

--- a/admin/tests/Feature/ReceiptTest.php
+++ b/admin/tests/Feature/ReceiptTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ReceiptTypeEnum;
+use App\Models\Order;
+use App\Models\Receipt;
+use App\Models\User;
+
+it('belongs to a user.', function (): void {
+    $receipt = Receipt::factory()->create();
+
+    expect($receipt->user)->toBeInstanceOf(User::class);
+});
+
+it('casts type, is_paya and paid_at.', function (): void {
+    $receipt = Receipt::factory()->create([
+        'type' => ReceiptTypeEnum::PREPAYMENT,
+        'is_paya' => true,
+        'paid_at' => now(),
+    ]);
+
+    expect($receipt->refresh()->type)->toBe(ReceiptTypeEnum::PREPAYMENT)
+        ->and($receipt->is_paya)->toBeTrue()
+        ->and($receipt->paid_at)->not->toBeNull();
+});
+
+it('can optionally link an order.', function (): void {
+    $order = Order::factory()->create();
+    $receipt = Receipt::factory()->create(['order_id' => $order->id]);
+
+    expect($receipt->order)->toBeInstanceOf(Order::class)
+        ->and($receipt->order->id)->toBe($order->id);
+});
+
+it('can have a polymorphic image that is removed on delete.', function (): void {
+    $receipt = Receipt::factory()->withImage()->create();
+    $image = $receipt->image;
+
+    expect($image)->not->toBeNull();
+
+    $receipt->delete();
+
+    $this->assertModelMissing($image);
+});
+
+it('keeps the receipt but nulls order_id when the order is deleted.', function (): void {
+    $order = Order::factory()->create();
+    $receipt = Receipt::factory()->create(['order_id' => $order->id]);
+
+    $order->delete();
+
+    expect($receipt->refresh()->order_id)->toBeNull();
+});


### PR DESCRIPTION
Adds the receipts table (model, migration, factory, seeder), ReceiptTypeEnum, a polymorphic receipt image, fa/en translations, a Filament resource (+ pages), and a ReceiptsRelationManager on the Order edit page. Includes model and resource tests. card_id stays nullable without FK (cards not built). Docs clarify receipts (manual payments) vs transactions/gateways (online).