### PR TITLE
feat: implement user_configs

### DIFF
--- a/admin/app/Filament/Resources/UserConfigResource.php
+++ b/admin/app/Filament/Resources/UserConfigResource.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UserConfigResource\Pages\CreateUserConfig;
+use App\Filament\Resources\UserConfigResource\Pages\EditUserConfig;
+use App\Filament\Resources\UserConfigResource\Pages\ListUserConfigs;
+use App\Models\UserConfig;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class UserConfigResource extends Resource
+{
+    protected static ?string $model = UserConfig::class;
+
+    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-adjustments-horizontal';
+
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('user_config.navigation_group');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans('user_config.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans('user_config.plural_label');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('user_id')
+                    ->label(trans('user_config.user_id'))
+                    ->relationship('user', 'email')
+                    ->required()
+                    ->searchable()
+                    ->preload()
+                    ->native(false),
+                TextInput::make('key')
+                    ->label(trans('user_config.key'))
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('label')
+                    ->label(trans('user_config.label_field'))
+                    ->maxLength(255),
+                Toggle::make('autoload')
+                    ->label(trans('user_config.autoload')),
+                Textarea::make('content')
+                    ->label(trans('user_config.content'))
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('id')
+                    ->label('#')
+                    ->sortable(),
+                TextColumn::make('user.email')
+                    ->label(trans('user_config.user_id'))
+                    ->searchable(),
+                TextColumn::make('key')
+                    ->label(trans('user_config.key'))
+                    ->searchable(),
+                TextColumn::make('label')
+                    ->label(trans('user_config.label_field'))
+                    ->searchable()
+                    ->limit(30)
+                    ->wrap(),
+                IconColumn::make('autoload')
+                    ->label(trans('user_config.autoload'))
+                    ->boolean()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label(trans('user_config.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUserConfigs::route('/'),
+            'create' => CreateUserConfig::route('/create'),
+            'edit' => EditUserConfig::route('/{record}/edit'),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/UserConfigResource/Pages/CreateUserConfig.php
+++ b/admin/app/Filament/Resources/UserConfigResource/Pages/CreateUserConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\UserConfigResource\Pages;
+
+use App\Filament\Resources\UserConfigResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUserConfig extends CreateRecord
+{
+    protected static string $resource = UserConfigResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/admin/app/Filament/Resources/UserConfigResource/Pages/EditUserConfig.php
+++ b/admin/app/Filament/Resources/UserConfigResource/Pages/EditUserConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\UserConfigResource\Pages;
+
+use App\Filament\Resources\UserConfigResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUserConfig extends EditRecord
+{
+    protected static string $resource = UserConfigResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/admin/app/Filament/Resources/UserConfigResource/Pages/ListUserConfigs.php
+++ b/admin/app/Filament/Resources/UserConfigResource/Pages/ListUserConfigs.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\UserConfigResource\Pages;
+
+use App\Filament\Resources\UserConfigResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUserConfigs extends ListRecords
+{
+    protected static string $resource = UserConfigResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/admin/app/Models/User.php
+++ b/admin/app/Models/User.php
@@ -101,4 +101,9 @@ class User extends Authenticatable implements FilamentUser, HasName
     {
         return $this->hasMany(Order::class);
     }
+
+    public function userConfigs(): HasMany
+    {
+        return $this->hasMany(UserConfig::class);
+    }
 }

--- a/admin/app/Models/UserConfig.php
+++ b/admin/app/Models/UserConfig.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Database\Factories\UserConfigFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property positive-int $id
+ * @property positive-int $user_id
+ * @property string $key
+ * @property string|null $label
+ * @property string|null $content
+ * @property bool $autoload
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property User|null $user
+ */
+class UserConfig extends Model
+{
+    /** @use HasFactory<UserConfigFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'key',
+        'label',
+        'content',
+        'autoload',
+    ];
+
+    protected $casts = [
+        'autoload' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/admin/database/factories/UserConfigFactory.php
+++ b/admin/database/factories/UserConfigFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\UserConfig;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UserConfig>
+ */
+class UserConfigFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'key' => fake()->unique()->slug(2),
+            'label' => fake()->optional()->words(2, true),
+            'content' => fake()->optional()->sentence(),
+            'autoload' => fake()->boolean(),
+        ];
+    }
+}

--- a/admin/database/migrations/2026_06_20_000021_create_user_configs_table.php
+++ b/admin/database/migrations/2026_06_20_000021_create_user_configs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_configs', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->string('key');
+            $table->string('label')->nullable();
+            $table->text('content')->nullable();
+            $table->boolean('autoload')->default(false);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_configs');
+    }
+};

--- a/admin/database/seeders/TestSeeder.php
+++ b/admin/database/seeders/TestSeeder.php
@@ -32,6 +32,7 @@ class TestSeeder extends Seeder
             ReceiptSeeder::class,
             TransactionSeeder::class,
             GatewaySeeder::class,
+            UserConfigSeeder::class,
             ShippingLineSeeder::class,
             ShippingMethodSeeder::class,
             ShippingCitySeeder::class,

--- a/admin/database/seeders/UserConfigSeeder.php
+++ b/admin/database/seeders/UserConfigSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\UserConfig;
+use Illuminate\Database\Seeder;
+
+class UserConfigSeeder extends Seeder
+{
+    public function run(): void
+    {
+        UserConfig::all()->each->delete();
+
+        UserConfig::factory()->count(10)->create();
+    }
+}

--- a/admin/docs/IMPLEMENTATION.md
+++ b/admin/docs/IMPLEMENTATION.md
@@ -120,7 +120,10 @@ The main goal; depends on most of phases 1-3.
 
 ## Phase 6 - Users extended & misc
 
-- [ ] `user_configs`, `user_roles`, `user_sources`, `user_statuses`, `user_permissions`
+- [x] `user_configs` (per-user key/value settings: model, migration, factory, seeder, Filament resource (+ pages), tests. `cascadeOnDelete` with the user; unique on `user_id`+`key`)
+- [~] `user_roles`, `user_permissions` — NOT NEEDED (covered by spatie's own user↔role / user↔permission pivots; their `seller_id` is irrelevant single-vendor)
+- [ ] `user_sources` — defer to accounting Sources (Phase 5)
+- [ ] `user_statuses` (per-user status restriction) — niche, not needed now
 - [ ] Category Partner, Partner Requests, Organizational Requests, Contact Us
 - [ ] Points, Newsletters, Notifications, System Notifications
 - [ ] `email_histories`, `mobile_histories`, `mobile_password_resets`

--- a/admin/docs/ShoFlow db doc.md
+++ b/admin/docs/ShoFlow db doc.md
@@ -839,6 +839,13 @@ This table is used to store user-related settings.
 * `content`: Used to store the settings value.  
 * `autoload`: If any settings are not needed globally, this column should be false, and this column should be cached.
 
+Implementation notes:
+
+* `user_id`: FK to `users`, `cascadeOnDelete` (settings are meaningless without the user).
+* Unique on (`user_id`, `key`) so a user has one value per key.
+* `label` and `content` are nullable; `autoload` is a boolean default `false`.
+* Standalone Filament resource under the Users navigation group.
+
 # user\_roles
 
 For storing each user's role.

--- a/admin/lang/en/user_config.php
+++ b/admin/lang/en/user_config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'User Setting',
+    'plural_label' => 'User Settings',
+    'navigation_group' => 'Users',
+    'subheading' => 'Per-user settings stored as key/value pairs.',
+
+    'user_id' => 'User',
+    'key' => 'Key',
+    'label_field' => 'Label',
+    'content' => 'Value',
+    'autoload' => 'Autoload',
+    'created_at' => 'Created At',
+    'updated_at' => 'Updated At',
+];

--- a/admin/lang/fa/user_config.php
+++ b/admin/lang/fa/user_config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'تنظیم کاربر',
+    'plural_label' => 'تنظیمات کاربر',
+    'navigation_group' => 'کاربران',
+    'subheading' => 'تنظیمات هر کاربر به صورت جفت کلید/مقدار.',
+
+    'user_id' => 'کاربر',
+    'key' => 'کلید',
+    'label_field' => 'عنوان',
+    'content' => 'مقدار',
+    'autoload' => 'بارگذاری خودکار',
+    'created_at' => 'تاریخ ایجاد',
+    'updated_at' => 'تاریخ بروزرسانی',
+];

--- a/admin/tests/Feature/Filament/Resource/UserConfigResourceTest.php
+++ b/admin/tests/Feature/Filament/Resource/UserConfigResourceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\UserConfigResource;
+use App\Models\User;
+use App\Models\UserConfig;
+use Filament\Actions\DeleteAction;
+
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    login();
+});
+
+it('can render index page of the user config resource.', function () {
+    get(UserConfigResource::getUrl())->assertOk();
+});
+
+it('can list user configs in the table.', function () {
+    $configs = UserConfig::factory()->count(5)->create();
+
+    livewire(UserConfigResource\Pages\ListUserConfigs::class)
+        ->assertCanSeeTableRecords($configs);
+});
+
+it('can render edit user config page.', function () {
+    $config = UserConfig::factory()->create();
+
+    get(UserConfigResource::getUrl('edit', [
+        'record' => $config,
+    ]))->assertOk();
+});
+
+it('can create user config model.', function () {
+    $user = User::factory()->create();
+
+    livewire(UserConfigResource\Pages\CreateUserConfig::class)
+        ->fillForm([
+            'user_id' => $user->id,
+            'key' => 'newsletter',
+            'label' => 'Newsletter',
+            'content' => 'enabled',
+            'autoload' => true,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(UserConfig::class, [
+        'user_id' => $user->id,
+        'key' => 'newsletter',
+        'content' => 'enabled',
+    ]);
+});
+
+it('can delete user config model.', function () {
+    $config = UserConfig::factory()->create();
+
+    livewire(UserConfigResource\Pages\EditUserConfig::class, [
+        'record' => $config->getRouteKey(),
+    ])
+        ->callAction(DeleteAction::class);
+
+    $this->assertModelMissing($config);
+});

--- a/admin/tests/Feature/UserConfigTest.php
+++ b/admin/tests/Feature/UserConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\UserConfig;
+
+it('belongs to a user.', function (): void {
+    $config = UserConfig::factory()->create();
+
+    expect($config->user)->toBeInstanceOf(User::class);
+});
+
+it('casts autoload to boolean.', function (): void {
+    $config = UserConfig::factory()->create(['autoload' => true]);
+
+    expect($config->refresh()->autoload)->toBeTrue();
+});
+
+it('is deleted when its user is deleted.', function (): void {
+    $user = User::factory()->create();
+    $config = UserConfig::factory()->create(['user_id' => $user->id]);
+
+    $user->delete();
+
+    $this->assertModelMissing($config);
+});


### PR DESCRIPTION
Per-user key/value settings: model, migration (cascade on user delete, unique user_id+key), factory, seeder, Filament resource (+ pages), and tests. Marks redundant user_roles/user_permissions as covered by spatie.